### PR TITLE
feat: Gitブランチ表示機能の実装 - プロンプトにブランチ名を緑色でハイライト表示

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -21,6 +21,18 @@ pub fn main() !void {
     _ = c.initscr();
     defer _ = c.endwin();
 
+    // カラー設定の初期化（Gitブランチ表示用）
+    if (c.has_colors()) {
+        _ = c.start_color();
+        // デフォルトカラーの使用を有効化
+        _ = c.use_default_colors();
+        // ブランチ名表示用のカラーペア（緑色）
+        _ = c.init_pair(1, c.COLOR_GREEN, -1);
+        // テスト用の追加カラーペア
+        _ = c.init_pair(2, c.COLOR_RED, -1);
+        _ = c.init_pair(3, c.COLOR_BLUE, -1);
+    }
+
     // カーソルを非表示に
     _ = c.curs_set(0);
 
@@ -41,14 +53,14 @@ pub fn main() !void {
 
 fn runMainLoop(terminal: *Terminal) !void {
     var running = true;
-    
+
     while (running) {
         // 画面の描画
         try terminal.draw();
-        
+
         // キー入力の処理
         const key = c.getch();
-        
+
         switch (key) {
             // Ctrl+C で終了
             3 => running = false,
@@ -87,4 +99,4 @@ test "basic terminal functionality" {
     // 基本的な機能のテスト
     try testing.expect(terminal.cursor_x == 0);
     try testing.expect(terminal.cursor_y == 0);
-} 
+}

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -54,12 +54,12 @@ pub const Terminal = struct {
         }
         self.lines.deinit();
         self.current_line.deinit();
-        
+
         for (self.command_history.items) |cmd| {
             cmd.deinit();
         }
         self.command_history.deinit();
-        
+
         self.shell.deinit();
     }
 
@@ -72,7 +72,7 @@ pub const Terminal = struct {
         self.width = c.COLS;
 
         var y: i32 = 0;
-        
+
         // 過去の行を描画
         for (self.lines.items) |line| {
             if (y >= self.height) break;
@@ -84,14 +84,37 @@ pub const Terminal = struct {
         if (y < self.height) {
             const prompt = try self.getPrompt();
             defer self.allocator.free(prompt);
-            
-            _ = c.mvprintw(y, 0, "%s%.*s", 
-                prompt.ptr, 
-                @as(c_int, @intCast(self.current_line.items.len)), 
-                self.current_line.items.ptr);
-            
-            // カーソル位置の設定
-            _ = c.move(y, @as(c_int, @intCast(prompt.len)) + self.cursor_x);
+
+            // プロンプトを描画し、ブランチのハイライト処理を行う
+            _ = c.move(y, 0);
+            var visible_prompt_len: usize = 0;
+
+            var i: usize = 0;
+            while (i < prompt.len) {
+                const START_MARKER = "§START§";
+                const END_MARKER = "§END§";
+
+                if (i + START_MARKER.len <= prompt.len and std.mem.eql(u8, prompt[i .. i + START_MARKER.len], START_MARKER)) {
+                    // ブランチ名開始マーカー
+                    _ = c.attron(c.COLOR_PAIR(1));
+                    i += START_MARKER.len;
+                } else if (i + END_MARKER.len <= prompt.len and std.mem.eql(u8, prompt[i .. i + END_MARKER.len], END_MARKER)) {
+                    // ブランチ名終了マーカー
+                    _ = c.attroff(c.COLOR_PAIR(1));
+                    i += END_MARKER.len;
+                } else {
+                    // 通常の文字
+                    _ = c.addch(prompt[i]);
+                    visible_prompt_len += 1;
+                    i += 1;
+                }
+            }
+
+            // コマンドライン部分を描画
+            _ = c.printw("%.*s", @as(c_int, @intCast(self.current_line.items.len)), self.current_line.items.ptr);
+
+            // カーソル位置の設定（マーカーを除いた実際の表示文字数に基づく）
+            _ = c.move(y, @as(c_int, @intCast(visible_prompt_len)) + self.cursor_x);
         }
 
         // 画面の更新
@@ -121,7 +144,7 @@ pub const Terminal = struct {
 
             // 現在の行（プロンプト付き）を履歴に追加
             var full_line = ArrayList(u8).init(self.allocator);
-            const prompt = try self.getPrompt();
+            const prompt = try self.getPromptForHistory();
             defer self.allocator.free(prompt);
             try full_line.appendSlice(prompt);
             try full_line.appendSlice(self.current_line.items);
@@ -129,7 +152,7 @@ pub const Terminal = struct {
 
             // コマンドの実行
             const result = try self.shell.execute(self.current_line.items);
-            
+
             // clearコマンドの特別処理
             if (std.mem.eql(u8, result, "\x1b[2J\x1b[H")) {
                 // 画面をクリアして行履歴も削除
@@ -155,7 +178,7 @@ pub const Terminal = struct {
         } else {
             // 空行の場合
             var empty_line = ArrayList(u8).init(self.allocator);
-            const prompt = try self.getPrompt();
+            const prompt = try self.getPromptForHistory();
             defer self.allocator.free(prompt);
             try empty_line.appendSlice(prompt);
             try self.lines.append(empty_line);
@@ -164,7 +187,7 @@ pub const Terminal = struct {
         // 新しいプロンプトの準備
         self.current_line.clearRetainingCapacity();
         self.cursor_x = 0;
-        
+
         // スクロール処理
         try self.handleScroll();
     }
@@ -215,32 +238,203 @@ pub const Terminal = struct {
 
     fn getPrompt(self: *Terminal) ![]const u8 {
         const cwd = self.shell.cwd.items;
-        
+
+        // Gitブランチ名の取得
+        var branch_name_owned: ?[]u8 = null;
+        defer if (branch_name_owned) |branch| self.allocator.free(branch);
+
+        // .gitディレクトリの確認
+        const dot_git_path = std.fs.path.join(self.allocator, &.{ cwd, ".git" }) catch null;
+        defer if (dot_git_path) |path| self.allocator.free(path);
+
+        if (dot_git_path) |git_path| {
+            const git_exists = blk: {
+                std.fs.cwd().access(git_path, .{}) catch break :blk false;
+                break :blk true;
+            };
+            if (git_exists) {
+                // Gitブランチ名の取得
+                var child = std.process.Child.init(&.{ "git", "symbolic-ref", "--short", "HEAD" }, self.allocator);
+
+                var cwd_dir = std.fs.cwd().openDir(cwd, .{}) catch null;
+                defer if (cwd_dir) |*dir| dir.close();
+
+                if (cwd_dir) |*dir| {
+                    child.cwd_dir = dir.*;
+                    child.stdout_behavior = .Pipe;
+                    child.stderr_behavior = .Ignore;
+
+                    var spawn_succeeded = true;
+                    child.spawn() catch {
+                        spawn_succeeded = false;
+                    };
+
+                    if (spawn_succeeded) {
+                        const MAX_BRANCH_NAME_LEN = 64;
+                        const raw_branch = child.stdout.?.reader().readAllAlloc(self.allocator, MAX_BRANCH_NAME_LEN) catch null;
+                        _ = child.wait() catch {};
+
+                        if (raw_branch) |branch_raw| {
+                            const trimmed = std.mem.trim(u8, branch_raw, " \n\r");
+                            if (trimmed.len > 0) {
+                                branch_name_owned = self.allocator.dupe(u8, trimmed) catch null;
+                            }
+                            self.allocator.free(branch_raw);
+                        }
+                    }
+                }
+            }
+        }
+
+        // プロンプトのパス部分を決定
+        var path_part: []const u8 = undefined;
+        var path_allocated = false;
+        defer if (path_allocated) self.allocator.free(path_part);
+
         // ホームディレクトリの場合は ~ で表示
         if (std.process.getEnvVarOwned(self.allocator, "HOME")) |home| {
             defer self.allocator.free(home);
             if (std.mem.startsWith(u8, cwd, home)) {
                 const relative_path = cwd[home.len..];
                 if (relative_path.len == 0) {
-                    return try self.allocator.dupe(u8, "~ $ ");
+                    path_part = "~";
                 } else {
-                    return try std.fmt.allocPrint(self.allocator, "~{s} $ ", .{relative_path});
+                    path_part = try std.fmt.allocPrint(self.allocator, "~{s}", .{relative_path});
+                    path_allocated = true;
+                }
+            } else {
+                // ディレクトリ名のみを表示（フルパスが長い場合）
+                if (std.mem.lastIndexOfScalar(u8, cwd, '/')) |last_slash| {
+                    const dir_name = cwd[last_slash + 1 ..];
+                    if (dir_name.len == 0) {
+                        path_part = "/";
+                    } else {
+                        path_part = dir_name;
+                    }
+                } else {
+                    path_part = cwd;
                 }
             }
         } else |_| {
-            // HOME環境変数が取得できない場合は何もしない
-        }
-        
-        // ディレクトリ名のみを表示（フルパスが長い場合）
-        if (std.mem.lastIndexOfScalar(u8, cwd, '/')) |last_slash| {
-            const dir_name = cwd[last_slash + 1..];
-            if (dir_name.len == 0) {
-                return try self.allocator.dupe(u8, "/ $ ");
+            // HOME環境変数が取得できない場合
+            if (std.mem.lastIndexOfScalar(u8, cwd, '/')) |last_slash| {
+                const dir_name = cwd[last_slash + 1 ..];
+                if (dir_name.len == 0) {
+                    path_part = "/";
+                } else {
+                    path_part = dir_name;
+                }
             } else {
-                return try std.fmt.allocPrint(self.allocator, "{s} $ ", .{dir_name});
+                path_part = cwd;
             }
         }
-        
-        return try std.fmt.allocPrint(self.allocator, "{s} $ ", .{cwd});
+
+        // プロンプト文字列の構築
+        if (branch_name_owned) |branch_name| {
+            // ブランチ情報付きプロンプト
+            const START_MARKER = "§START§";
+            const END_MARKER = "§END§";
+            return try std.fmt.allocPrint(self.allocator, "{s} ({s}{s}{s}) $ ", .{ path_part, START_MARKER, branch_name, END_MARKER });
+        } else {
+            // 通常のプロンプト
+            return try std.fmt.allocPrint(self.allocator, "{s} $ ", .{path_part});
+        }
     }
-}; 
+
+    // 履歴表示用のマーカーなしプロンプトを生成
+    fn getPromptForHistory(self: *Terminal) ![]const u8 {
+        const cwd = self.shell.cwd.items;
+
+        // Gitブランチ名の取得（getPrompt関数と同じロジック）
+        var branch_name_owned: ?[]u8 = null;
+        defer if (branch_name_owned) |branch| self.allocator.free(branch);
+
+        const dot_git_path = std.fs.path.join(self.allocator, &.{ cwd, ".git" }) catch null;
+        defer if (dot_git_path) |path| self.allocator.free(path);
+
+        if (dot_git_path) |git_path| {
+            const git_exists = blk: {
+                std.fs.cwd().access(git_path, .{}) catch break :blk false;
+                break :blk true;
+            };
+            if (git_exists) {
+                var child = std.process.Child.init(&.{ "git", "symbolic-ref", "--short", "HEAD" }, self.allocator);
+
+                var cwd_dir = std.fs.cwd().openDir(cwd, .{}) catch null;
+                defer if (cwd_dir) |*dir| dir.close();
+
+                if (cwd_dir) |*dir| {
+                    child.cwd_dir = dir.*;
+                    child.stdout_behavior = .Pipe;
+                    child.stderr_behavior = .Ignore;
+
+                    var spawn_succeeded = true;
+                    child.spawn() catch {
+                        spawn_succeeded = false;
+                    };
+
+                    if (spawn_succeeded) {
+                        const MAX_BRANCH_NAME_LEN = 64;
+                        const raw_branch = child.stdout.?.reader().readAllAlloc(self.allocator, MAX_BRANCH_NAME_LEN) catch null;
+                        _ = child.wait() catch {};
+
+                        if (raw_branch) |branch_raw| {
+                            const trimmed = std.mem.trim(u8, branch_raw, " \n\r");
+                            if (trimmed.len > 0) {
+                                branch_name_owned = self.allocator.dupe(u8, trimmed) catch null;
+                            }
+                            self.allocator.free(branch_raw);
+                        }
+                    }
+                }
+            }
+        }
+
+        // プロンプトのパス部分を決定
+        var path_part: []const u8 = undefined;
+        var path_allocated = false;
+        defer if (path_allocated) self.allocator.free(path_part);
+
+        if (std.process.getEnvVarOwned(self.allocator, "HOME")) |home| {
+            defer self.allocator.free(home);
+            if (std.mem.startsWith(u8, cwd, home)) {
+                const relative_path = cwd[home.len..];
+                if (relative_path.len == 0) {
+                    path_part = "~";
+                } else {
+                    path_part = try std.fmt.allocPrint(self.allocator, "~{s}", .{relative_path});
+                    path_allocated = true;
+                }
+            } else {
+                if (std.mem.lastIndexOfScalar(u8, cwd, '/')) |last_slash| {
+                    const dir_name = cwd[last_slash + 1 ..];
+                    if (dir_name.len == 0) {
+                        path_part = "/";
+                    } else {
+                        path_part = dir_name;
+                    }
+                } else {
+                    path_part = cwd;
+                }
+            }
+        } else |_| {
+            if (std.mem.lastIndexOfScalar(u8, cwd, '/')) |last_slash| {
+                const dir_name = cwd[last_slash + 1 ..];
+                if (dir_name.len == 0) {
+                    path_part = "/";
+                } else {
+                    path_part = dir_name;
+                }
+            } else {
+                path_part = cwd;
+            }
+        }
+
+        // マーカーなしプロンプト文字列の構築
+        if (branch_name_owned) |branch_name| {
+            return try std.fmt.allocPrint(self.allocator, "{s} ({s}) $ ", .{ path_part, branch_name });
+        } else {
+            return try std.fmt.allocPrint(self.allocator, "{s} $ ", .{path_part});
+        }
+    }
+};


### PR DESCRIPTION
## 概要

ターミナルエミュレーターのプロンプトに現在の Git ブランチ名を緑色でハイライト表示する機能を追加しました。

## 実装した機能

- Git リポジトリ内でプロンプトにブランチ名を表示
- ブランチ名を緑色でハイライト
- 非 Git ディレクトリでは従来通りのプロンプト表示

## 仕様

### プロンプト表示形式

- **Git リポジトリ内**: `ディレクトリ名 (ブランチ名) $ ` （ブランチ名は緑色）
- **通常ディレクトリ**: `ディレクトリ名 $ `

### 動作

- `.git` ディレクトリの存在確認
- `git symbolic-ref --short HEAD` でブランチ名取得
- 取得に失敗した場合は通常プロンプトを表示

## テスト方法

```bash
# ビルドと実行
zig build
./zig-out/bin/zterm

# Git リポジトリ内でブランチ名が緑色で表示されることを確認
# 非 Git ディレクトリではブランチ名が表示されないことを確認
```

## 変更ファイル

- `src/main.zig`: ncurses カラー設定の追加
- `src/terminal.zig`: ブランチ検出とハイライト表示ロジックの実装

---

**ブランチ**: `feature/git-branch-display`  
**コミット**: `f9f9ae0` - feat: Git ブランチ表示機能の実装
