### PR TITLE
fix: vim などのインタラクティブプログラム実行時の画面固定問題を修正

### DIFF
--- a/src/shell.zig
+++ b/src/shell.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
 const ChildProcess = std.process.Child;
+const c = @cImport({
+    @cInclude("ncurses.h");
+});
 
 pub const Shell = struct {
     allocator: Allocator,
@@ -10,7 +13,7 @@ pub const Shell = struct {
 
     pub fn init(allocator: Allocator) !Shell {
         const env = try std.process.getEnvMap(allocator);
-        
+
         var cwd = ArrayList(u8).init(allocator);
         const current_dir = std.fs.cwd().realpathAlloc(allocator, ".") catch |err| switch (err) {
             error.FileNotFound => try allocator.dupe(u8, "/"),
@@ -77,6 +80,19 @@ pub const Shell = struct {
         return try self.executeExternal(args.items);
     }
 
+    // インタラクティブなプログラムかどうかを判定
+    fn isInteractiveProgram(self: *Shell, command: []const u8) bool {
+        _ = self; // suppress unused parameter warning
+        const interactive_programs = [_][]const u8{ "vim", "nvim", "nano", "emacs", "less", "more", "man", "top", "htop", "vi", "edit", "pico", "joe", "micro", "helix", "tmux", "screen", "bash", "zsh", "fish", "sh", "csh", "tcsh", "ksh", "dash" };
+
+        for (interactive_programs) |prog| {
+            if (std.mem.eql(u8, command, prog)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     fn handleCd(self: *Shell, args: []const []const u8) ![]const u8 {
         const target_dir = if (args.len > 1) args[1] else {
             // HOMEディレクトリに移動
@@ -93,7 +109,7 @@ pub const Shell = struct {
         // パスの正規化
         var target_path: []const u8 = undefined;
         var should_free_target_path = false;
-        
+
         if (target_dir[0] == '/') {
             // 絶対パス
             target_path = target_dir;
@@ -101,13 +117,13 @@ pub const Shell = struct {
             // 相対パス - 現在のディレクトリから解決
             var new_path = ArrayList(u8).init(self.allocator);
             defer new_path.deinit();
-            
+
             try new_path.appendSlice(self.cwd.items);
             if (self.cwd.items[self.cwd.items.len - 1] != '/') {
                 try new_path.append('/');
             }
             try new_path.appendSlice(target_dir);
-            
+
             target_path = try self.allocator.dupe(u8, new_path.items);
             should_free_target_path = true;
         }
@@ -123,7 +139,7 @@ pub const Shell = struct {
         const stat = std.fs.cwd().statFile(real_path) catch {
             return try std.fmt.allocPrint(self.allocator, "cd: {s}: Permission denied", .{target_dir});
         };
-        
+
         if (stat.kind != .directory) {
             return try std.fmt.allocPrint(self.allocator, "cd: {s}: Not a directory", .{target_dir});
         }
@@ -157,11 +173,11 @@ pub const Shell = struct {
 
     fn handleLs(self: *Shell, args: []const []const u8) ![]const u8 {
         const target_dir = if (args.len > 1) args[1] else ".";
-        
+
         // パスの解決
         var full_path: []const u8 = undefined;
         var should_free_path = false;
-        
+
         if (target_dir[0] == '/') {
             // 絶対パス
             full_path = target_dir;
@@ -172,18 +188,18 @@ pub const Shell = struct {
             // 相対パス - 現在のディレクトリから解決
             var path_buf = ArrayList(u8).init(self.allocator);
             defer path_buf.deinit();
-            
+
             try path_buf.appendSlice(self.cwd.items);
             if (self.cwd.items[self.cwd.items.len - 1] != '/') {
                 try path_buf.append('/');
             }
             try path_buf.appendSlice(target_dir);
-            
+
             full_path = try self.allocator.dupe(u8, path_buf.items);
             should_free_path = true;
         }
         defer if (should_free_path) self.allocator.free(full_path);
-        
+
         var dir = std.fs.openDirAbsolute(full_path, .{ .iterate = true }) catch {
             return try std.fmt.allocPrint(self.allocator, "ls: {s}: No such file or directory", .{target_dir});
         };
@@ -224,6 +240,10 @@ pub const Shell = struct {
             \\  help        - Show this help
             \\  exit        - Exit terminal
             \\
+            \\External commands:
+            \\  Any system command, including interactive programs like:
+            \\  vim, nano, emacs, less, man, top, htop, etc.
+            \\
             \\Key bindings:
             \\  Ctrl+C, Ctrl+D, ESC - Exit
             \\  Up/Down arrows - Command history
@@ -235,12 +255,58 @@ pub const Shell = struct {
     }
 
     fn executeExternal(self: *Shell, args: []const []const u8) ![]const u8 {
+        const command = args[0];
+        const is_interactive = self.isInteractiveProgram(command);
+
+        if (is_interactive) {
+            // インタラクティブなプログラムの場合
+            return try self.executeInteractiveProgram(args);
+        } else {
+            // 通常のプログラムの場合
+            return try self.executeNormalProgram(args);
+        }
+    }
+
+    fn executeInteractiveProgram(self: *Shell, args: []const []const u8) ![]const u8 {
+        // ncursesを一時停止
+        _ = c.def_prog_mode(); // 現在のターミナル設定を保存
+        _ = c.endwin(); // ncursesを終了
+
         var process = ChildProcess.init(args, self.allocator);
-        
+
         // shell内部の現在のディレクトリを作業ディレクトリとして設定
         process.cwd_dir = std.fs.openDirAbsolute(self.cwd.items, .{}) catch null;
         defer if (process.cwd_dir) |*dir| dir.close();
-        
+
+        // インタラクティブプログラムはstdin/stdout/stderrを直接使用
+        process.stdin_behavior = .Inherit;
+        process.stdout_behavior = .Inherit;
+        process.stderr_behavior = .Inherit;
+
+        const spawn_result = process.spawn();
+        if (spawn_result) |_| {
+            _ = process.wait() catch {};
+        } else |_| {
+            // ncursesを再開
+            _ = c.reset_prog_mode(); // 保存された設定を復元
+            _ = c.refresh(); // 画面を更新
+            return try std.fmt.allocPrint(self.allocator, "{s}: command not found", .{args[0]});
+        }
+
+        // ncursesを再開
+        _ = c.reset_prog_mode(); // 保存された設定を復元
+        _ = c.refresh(); // 画面を更新
+
+        return try self.allocator.dupe(u8, "");
+    }
+
+    fn executeNormalProgram(self: *Shell, args: []const []const u8) ![]const u8 {
+        var process = ChildProcess.init(args, self.allocator);
+
+        // shell内部の現在のディレクトリを作業ディレクトリとして設定
+        process.cwd_dir = std.fs.openDirAbsolute(self.cwd.items, .{}) catch null;
+        defer if (process.cwd_dir) |*dir| dir.close();
+
         process.stdout_behavior = .Pipe;
         process.stderr_behavior = .Pipe;
 
@@ -250,7 +316,7 @@ pub const Shell = struct {
 
         const stdout = process.stdout.?.reader().readAllAlloc(self.allocator, 1024 * 1024) catch "";
         const stderr = process.stderr.?.reader().readAllAlloc(self.allocator, 1024 * 1024) catch "";
-        
+
         const term = process.wait() catch {
             return try std.fmt.allocPrint(self.allocator, "{s}: failed to execute process", .{args[0]});
         };
@@ -282,4 +348,4 @@ pub const Shell = struct {
 
         return try self.allocator.dupe(u8, result.items);
     }
-}; 
+};


### PR DESCRIPTION
## 問題の概要

vim や nano などのインタラクティブなプログラムを実行した際に、画面が固まってしまう問題がありました。

### 発生していた現象

- `vim`、`nano`、`less`、`man`などのコマンドを実行すると画面が応答しなくなる
- プログラム自体は動作しているが、ユーザーインターフェースが表示されない
- 強制終了しかできない状態になる

### 原因分析

この問題は、ncurses がターミナルを制御している状態で、同様にターミナル制御を必要とするプログラムが実行されることによる競合が原因でした。

## 解決方法

インタラクティブなプログラムを実行する際に以下の対応を実装しました：

### 1. プログラム判定機能の追加

一般的なインタラクティブプログラムを自動判定する機能を追加：

- テキストエディタ: `vim`, `nvim`, `nano`, `emacs`, `vi`, `edit`, `pico`, `joe`, `micro`, `helix`
- ページャー: `less`, `more`, `man`
- システム監視: `top`, `htop`
- ターミナルマルチプレクサ: `tmux`, `screen`
- シェル: `bash`, `zsh`, `fish`, `sh`, `csh`, `tcsh`, `ksh`, `dash`

### 2. ncurses の一時停止機能

インタラクティブプログラム実行前に：

- `def_prog_mode()`: 現在のターミナル設定を保存
- `endwin()`: ncurses を終了し、ターミナルの制御権を解放

### 3. 直接端末制御の設定

プログラムがターミナルを直接制御できるよう設定：

- `stdin_behavior = .Inherit`
- `stdout_behavior = .Inherit`
- `stderr_behavior = .Inherit`

### 4. ncurses の再初期化

プログラム終了後に：

- `reset_prog_mode()`: 保存されたターミナル設定を復元
- `refresh()`: 画面を更新してターミナルエミュレータを再描画

## 変更内容

### `src/shell.zig`

- `isInteractiveProgram()`: インタラクティブプログラム判定メソッドを追加
- `executeInteractiveProgram()`: インタラクティブプログラム専用実行メソッドを追加
- `executeNormalProgram()`: 通常のプログラム実行メソッドを分離
- `executeExternal()`: プログラムタイプに応じて実行方法を分岐
- `handleHelp()`: ヘルプメッセージにインタラクティブプログラムサポートの説明を追加

### `src/terminal.zig`

- `getFirstCommand()`: コマンドライン解析メソッドを追加
- `isInteractiveCommand()`: インタラクティブコマンド判定メソッドを追加
- `handleEnter()`: インタラクティブプログラム実行時の特別な処理を追加
- インタラクティブプログラム実行後の画面クリアと再描画処理を改善

## テスト

以下のプログラムで動作確認済み：

- ✅ `vim` - 正常に起動・編集・終了が可能
- ✅ `nano` - 正常に起動・編集・終了が可能
- ✅ `less` - ファイル閲覧が正常に動作
- ✅ `man` - マニュアル表示が正常に動作
- ✅ `top` - システム監視が正常に動作

プログラム終了後にターミナルエミュレータが正常に動作することも確認済みです。

## 互換性

- 既存の内蔵コマンド（`cd`, `pwd`, `ls`, `echo`, `clear`, `help`, `exit`）には影響なし
- 非インタラクティブな外部コマンドの動作も変更なし
- 新規追加機能のため、既存コードとの互換性を維持

## 今後の拡張

必要に応じて以下の改善が可能：

- インタラクティブプログラムリストの設定ファイル化
- ユーザー定義のインタラクティブプログラム追加機能
- より高度なターミナル制御の実装

---